### PR TITLE
fix: se permite publicar reportes de ambos tipos

### DIFF
--- a/lib/appbar.dart
+++ b/lib/appbar.dart
@@ -150,14 +150,18 @@ class _BotonMenu extends StatelessWidget {
             Text(descripcion!),
           ],
         ),
-        onTap: () => navKey.currentState!.push(
-          MaterialPageRoute(
-            builder: (_) {
-              final uuid = Uuid().v7();
-              return ReportDisplay.vacio(uuid, modo: Modo.Editar, tipo: tipo);
-            },
-          ),
-        ),
+        onTap: () {
+          Navigator.pop(context);
+          navKey.currentState!.push(
+            MaterialPageRoute(
+              builder: (_) {
+                final uuid = Uuid().v7();
+
+                return ReportDisplay.vacio(uuid, modo: Modo.Editar, tipo: tipo);
+              },
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/report_display.dart
+++ b/lib/report_display.dart
@@ -237,7 +237,8 @@ class _ReportDisplayState extends State<ReportDisplay> {
   }
 
   void _publicarYSalir(BuildContext context) {
-    if (_publicar(context)) Navigator.pop(context);
+    if (_publicar(context))
+      Navigator.of(context, rootNavigator: true).pop();
   }
 
   Reporte _recolectarCambios() {


### PR DESCRIPTION
## Descripcion
Ahora se pueden crear reportes tanto de objetos perdidos como encontrados

## Resumen de cambios

- Se creo un dialogo en la appbar para permitir crear reportes
- Se cambio una linea de report_display para arreglar un bug del dialogo

## Testing y verificación

Probar crear ambos tipos de reporte

## Detalles adicionales

resolves #1  #4 